### PR TITLE
bug 45 resolved

### DIFF
--- a/src/pages/LoginRegister.jsx
+++ b/src/pages/LoginRegister.jsx
@@ -38,7 +38,7 @@ const LoginRegister = () => {
     }, []);
 
     const passwordRequirements = [
-        {regex: /.{8,15}/, text: "Entre 8 y 15 caracteres"},
+        {regex: /.{8,10}/, text: "Entre 8 y 10 caracteres"},
         {regex: /[A-Z]/, text: "Al menos una letra mayúscula"},
         {regex: /[a-z]/, text: "Al menos una letra minúscula"},
         {regex: /[0-9]/, text: "Al menos un número"},
@@ -253,6 +253,7 @@ const LoginRegister = () => {
                                         handleBlur('password');
                                         setShowPasswordRequirements(false);
                                     }}
+                                    maxLength={10}
                                     required
                                 />
                                 <button
@@ -297,6 +298,7 @@ const LoginRegister = () => {
                                     value={confirmPassword}
                                     onChange={(e) => setConfirmPassword(e.target.value)}
                                     onBlur={() => handleBlur('confirmPassword')}
+                                    maxLength={10}
                                     required
                                 />
                                 <button


### PR DESCRIPTION
This pull request is to fix bug #45 reported by the QA team, which is that when registering a new user, the character limit should be a maximum of 10 in the password field, but currently there was no limit despite the fact that in the acceptance criteria we were told that it would be a maximum of 10 characters.
To solve the bug, a modification was made to the LoginRegister.jsx page where we put a maximum limit of 10 characters in the "password" and "confirm password" fields.