### PR TITLE
Fix code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/src/components/TaskEditDialog.jsx
+++ b/src/components/TaskEditDialog.jsx
@@ -41,12 +41,17 @@ export default function TaskEditDialog({
 
   const validateUrl = (url) => {
     if (!url.trim()) return false;
-    if (
-      url.startsWith("trackmaster.systems") ||
-      url.startsWith("http://trackmaster.systems") ||
-      url.startsWith("https://trackmaster.systems")
-    ) {
-      return true;
+    try {
+      const parsedUrl = new URL(url);
+      const allowedHosts = [
+        'trackmaster.systems',
+        'www.trackmaster.systems'
+      ];
+      if (allowedHosts.includes(parsedUrl.host)) {
+        return true;
+      }
+    } catch (e) {
+      return false;
     }
     const pattern = new RegExp(
       "^(https?:\\/\\/)?" +


### PR DESCRIPTION
Fixes [https://github.com/RedFox-SRL/frontend/security/code-scanning/2](https://github.com/RedFox-SRL/frontend/security/code-scanning/2)

To fix the problem, we need to parse the URL and check its host value against a whitelist of allowed hosts. This ensures that the URL is not maliciously crafted to include "trackmaster.systems" in an unintended part of the URL. We will use the `URL` constructor available in modern JavaScript to parse the URL and extract its host.

- Modify the `validateUrl` function to parse the URL and check its host against a whitelist of allowed hosts.
- Update the code to use the `URL` constructor for parsing.
- Ensure that the allowed hosts are explicitly listed and checked.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
